### PR TITLE
Add ZIP download feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# 20250605_YoutubeDownloaderWeb
-20250605_YoutubeDownloaderWeb
+# Youtube Playlist Downloader Web
+
+This simple Streamlit app allows you to download every video from a YouTube playlist.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the app:
+
+```bash
+streamlit run app.py
+```
+
+## Usage
+
+1. Enter a YouTube playlist URL.
+2. (Optional) Upload a `cookies.txt` file if the playlist requires login.
+3. Press **Download Playlist** to download all videos. After the download finishes a zip archive of the playlist is created and a **Download ZIP** button will appear allowing you to save it locally.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+import tempfile
+import streamlit as st
+from yt_dlp import YoutubeDL
+
+st.title("YouTube Playlist Downloader")
+
+playlist_url = st.text_input("Playlist URL")
+
+cookie_file = st.file_uploader("Upload cookies.txt (optional)", type=["txt"])
+
+DOWNLOAD_DIR = "downloads"
+os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+
+if st.button("Download Playlist"):
+    if playlist_url:
+        ydl_opts = {
+            'outtmpl': os.path.join(DOWNLOAD_DIR, '%(playlist_title)s/%(title)s.%(ext)s'),
+            'ignoreerrors': True,
+            'nocheckcertificate': True
+        }
+        tmp_cookie_path = None
+        if cookie_file is not None:
+            with tempfile.NamedTemporaryFile(delete=False, mode='wb', suffix='.txt') as tmp:
+                tmp.write(cookie_file.read())
+                tmp_cookie_path = tmp.name
+            ydl_opts['cookiefile'] = tmp_cookie_path
+
+        with YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(playlist_url, download=False)
+            playlist_title = info.get('title', 'playlist')
+            ydl.download([playlist_url])
+
+        playlist_path = os.path.join(DOWNLOAD_DIR, playlist_title)
+        zip_file = shutil.make_archive(playlist_path, 'zip', playlist_path)
+
+        if tmp_cookie_path:
+            os.remove(tmp_cookie_path)
+
+        st.success("Download completed.")
+        with open(zip_file, "rb") as f:
+            st.download_button("Download ZIP", f, file_name=f"{playlist_title}.zip")
+    else:
+        st.error("Please provide a playlist URL.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+yt-dlp


### PR DESCRIPTION
## Summary
- allow zipping downloaded playlist and offer a download button
- document the ZIP download step in README

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d52d6f7c8330bc7e2e80d3b23c5e